### PR TITLE
Security Fix for Prototype Pollution - huntr.dev

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,16 @@ var indexOf = [].indexOf || function(elt/*,from*/) {
   return -1
 }
 
+/**
+ * Returns true, if given key is included in the blacklisted
+ * keys.
+ * @param {String} key key for check, string.
+ * @returns {Boolean}.
+ */
+function isPrototypePolluted(key) {
+  return ['__proto__', 'prototype', 'constructor'].includes(key);
+}
+
 // based on Bergi's https://stackoverflow.com/questions/19098797/fastest-way-to-flatten-un-flatten-nested-json-objects
 
 function flatten(data, sortKeysFlag) {
@@ -64,7 +74,9 @@ function unflatten(data) {
     do {
       idx = indexOf.call(p, ".", last)
       temp = p.substring(last, ~idx ? idx : undefined)
-      cur = cur[prop] || (cur[prop] = (!isNaN(parseInt(temp)) ? [] : {}))
+      if (!isPrototypePolluted(prop)) {
+        cur = cur[prop] || (cur[prop] = (!isNaN(parseInt(temp)) ? [] : {}))
+      }
       prop = temp
       last = idx + 1
     } while(idx >= 0)

--- a/index.spec.js
+++ b/index.spec.js
@@ -64,6 +64,18 @@ describe('nested-objects-util', () => {
         }
       })
     })
+
+
+    it('should prevent prototype pollution on unflattening an object', () => {
+      const unflattened = nestedObjectsUtil.unflatten({
+        "__proto__.polluted": "Yes! Its Polluted"
+      })
+      assert.deepEqual(unflattened, {
+        polluted: "Yes! Its Polluted"
+      })
+      assert.notEqual({}.polluted, "Yes! Its Polluted")
+      assert.equal({}.polluted, undefined)
+    })
   })
 
   describe('accessProperty', () => {


### PR DESCRIPTION
https://huntr.dev/users/d3v53c has fixed the Prototype Pollution vulnerability 🔨. Think you could fix a vulnerability like this?

Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/nested-objects-util/pull/2
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/nested-objects-util/1/README.md

### User Comments:

### 📊 Metadata *

nested-objects-util is vulnerable to Prototype Pollution.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-nested-objects-util

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes. The bug is fixed by validating the input strArray to check for prototypes. It is implemented by a simple validation to check for prototype keywords (proto, constructor and prototype), where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability.

### 🐛 Proof of Concept (PoC) *

Create the following PoC file:

```
// poc.js
var {unflatten} = require("nested-objects-util")
console.log("Before : " + {}.polluted);
unflatten({"__proto__.polluted": "Yes! Its Polluted"})
console.log("After : " + {}.polluted);
```

Execute the following commands in terminal:

```
npm i nested-objects-util # Install affected module
node poc.js #  Run the PoC
```

Check the Output:

```
Before : undefined
After : Yes! Its Polluted
```

### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/102828165-0342c000-440a-11eb-87b3-778d55f3d02d.png)

After:
![image](https://user-images.githubusercontent.com/64132745/102828211-20778e80-440a-11eb-9126-696d17918234.png)

### 👍 User Acceptance Testing (UAT)

![image](https://user-images.githubusercontent.com/64132745/104122864-8900be00-536d-11eb-8018-01e89a425e15.png)

After applying the fix, functionality is unaffected.

### 🔗 Relates to...

https://www.huntr.dev/bounties/1-npm-nested-objects-util/
